### PR TITLE
Toast: Clear interval when component unmounts.

### DIFF
--- a/src/Toast.js
+++ b/src/Toast.js
@@ -37,6 +37,11 @@ class Toast extends Component {
     this.showToast()
   }
 
+  componentWillUnmount () {
+    const { timeoutId } = this.state;
+    clearTimeout(timeoutId)
+  }
+
   componentWillReceiveProps (nextProps) {
     if (this.props.id !== nextProps.id) {
       this.showToast()


### PR DESCRIPTION
This fixes updating the component after it has been unmounted already. The component is showing a warning otherwise. Being:

`Warning: Can only update a mounted or mounting component. This usually means you called setState, replaceState, or forceUpdate on an unmounted component. This is a no-op.`