### PR TITLE
fix: toaster not showing on android 6 and above

### DIFF
--- a/src/Toast.js
+++ b/src/Toast.js
@@ -104,6 +104,7 @@ class Toast extends Component {
         right: 0,
         left: 0,
         zIndex: 9999,
+        elevation: 9999,
         transform: [{ translateY: y }]
       }}>
         <TouchableWithoutFeedback onPress={this.onPress}>


### PR DESCRIPTION
Fixes https://github.com/tableflip/react-native-toaster/issues/18